### PR TITLE
fix resetpwd page can not to manager page

### DIFF
--- a/src/views/OrgSelect.vue
+++ b/src/views/OrgSelect.vue
@@ -71,6 +71,7 @@
             },
             submit() {
                 let data = JSON.parse(JSON.stringify(this.$store.state.loginInfo));
+                this.$store.commit('setPwdIsChanged', data.userInfo[this.orgValue].initial_pw_changed);
                 Object.assign(data, {orgValue: this.orgValue});
                 this.setCorpTokenAct(data.userInfo[this.orgValue].token);
                 this.setLoginInfoAct(data);


### PR DESCRIPTION
解决不同社区下存在相同的账号和密码时，更改密码之后再次进入重置密码界面，无法正确退出的问题